### PR TITLE
Enable new Rubocop 80 cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,6 +72,12 @@ Style/Documentation:
   Enabled: false
 Style/GuardClause:
   Enabled: false
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
 Style/Lambda:
   EnforcedStyle: literal
 Style/StringLiterals:


### PR DESCRIPTION
Rubocop will not enable new "default" cops until major releases now. It's up to us to enable them if we want.
https://github.com/rubocop-hq/rubocop/issues/7731