### PR TITLE
Enable rubocop 0.81 cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,11 @@ Layout/MultilineAssignmentLayout:
   Enabled: true
   EnforcedStyle: new_line
 
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+
 Performance/StringReplacement:
   Enabled: false
 


### PR DESCRIPTION
Enable cops added in Rubocop 0.81

> The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
>  - [Lint/RaiseException ](https://rubocop.readthedocs.io/en/latest/cops_lint/#lintraiseexception)(0.81)
>  - [Lint/StructNewOverride](https://rubocop.readthedocs.io/en/latest/cops_lint/#lintstructnewoverride) (0.81)