### PR TITLE
Enable 0.82 cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,8 @@ Layout/MultilineAssignmentLayout:
   Enabled: true
   EnforcedStyle: new_line
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
 Lint/RaiseException:
   Enabled: true
 Lint/StructNewOverride:
@@ -75,6 +77,8 @@ RSpec/LetSetup:
 
 Style/Documentation:
   Enabled: false
+Style/ExponentialNotation:
+  Enabled: true
 Style/GuardClause:
   Enabled: false
 Style/HashEachMethods:


### PR DESCRIPTION
Enable 0.82 cops

>The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
> - Layout/SpaceAroundMethodCallOperator (0.82)
> - Style/ExponentialNotation (0.82)
