### PR TITLE
Enable new cops globally

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ AllCops:
     - tmp/**/*
     - vendor/**/*
     - node_modules/**/*
+  # Enable all newly added Cops
+  NewCops: enable
 
 Rails:
   Enabled: true
@@ -53,13 +55,6 @@ Layout/LineLength:
 Layout/MultilineAssignmentLayout:
   Enabled: true
   EnforcedStyle: new_line
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
 
 Performance/StringReplacement:
   Enabled: false
@@ -77,16 +72,8 @@ RSpec/LetSetup:
 
 Style/Documentation:
   Enabled: false
-Style/ExponentialNotation:
-  Enabled: true
 Style/GuardClause:
   Enabled: false
-Style/HashEachMethods:
-  Enabled: true
-Style/HashTransformKeys:
-  Enabled: true
-Style/HashTransformValues:
-  Enabled: true
 Style/Lambda:
   EnforcedStyle: literal
 Style/StringLiterals:


### PR DESCRIPTION
Instead of enabling new cops manually, let Rubocop enable them. This will help when running CI on repository where the version of Rubocop hasn't been updated yet. This also simplify the process of updating Rubocop between repos. If we don't want a new cop, we would disable it here.

I removed the cops that were added because of updates.