### PR TITLE
Restore rubocop line length to the official setting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,6 @@ Metrics/ModuleLength:
     - 'spec/**/*'
 
 Layout/LineLength:
-  Max: 100
   Exclude:
     # Files below are ignored because they are part of rails and we don't want
     # to have to deal with line length in them.


### PR DESCRIPTION
The official setting was recently bumped to 120 chars in https://github.com/rubocop-hq/rubocop/pull/7952
We had it bumped from 80 to 100, but it doesn't make sense anymore to have it smaller than the default.

This will probably require a batch of fixes in each repos, but I'm pretty sure they are all autocorrect, and I'm all for a larger line length.