### PR TITLE
Replace BlockLength ExcludedMethods option with IgnoredMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Rails:
 Metrics/AbcSize:
   Max: 30
 Metrics/BlockLength:
-  ExcludedMethods:
+  IgnoredMethods:
     - configure
     - draw
     - guard


### PR DESCRIPTION
The option was renamed as of rubocop 1.5.0
The old name is still supported for now, but displays a warning

On ne peut pas merger cette PR tant qu'il y aura des configs de rubocop qui héritent de celle-ci et n'utilisent pas rubocop 1.5.0+. Liste des PR à merger avant de merger celle-ci : 
- [x] https://github.com/hooktstudios/soutex-website/pull/347 (Bump rubocop de Dependabot)
- [x] https://github.com/hooktstudios/fx-api/pull/558 (Bump rubocop de Dependabot)
- [x] https://github.com/hooktstudios/didacte-site/pull/573 (Update rubocop fait à la main à cause de gems problématiques)