### PR TITLE
Update rubocop option IgnoredMethods to AllowedMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Rails:
 Metrics/AbcSize:
   Max: 30
 Metrics/BlockLength:
-  IgnoredMethods:
+  AllowedMethods:
     - configure
     - draw
     - guard


### PR DESCRIPTION
This is fixing this obsolete warning, but we need to update all our repos to [Rubocop 1.33 or newer](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#1330-2022-08-04) before merging.

![image](https://user-images.githubusercontent.com/143380/186493572-e4cd5620-44fa-4478-a122-18af217ab5fe.png)

https://github.com/rubocop/rubocop/pull/10829

- [x] Update didacte-site to rubocop 1.33+
- [x] Update didacte to rubocop 1.33+
- [x] Update fx-api to rubocop 1.33+

Dependabot PRs are not opened yet on these repository, they should be on next refresh.