### PR TITLE
Add common methods and blocks used in migrations to AllowedMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,9 @@ Metrics/BlockLength:
     - configure
     - draw
     - guard
+    - safety_assured
     - setup
+    - up_only
   Exclude:
     - 'spec/**/*'
     - '**/*.rake'
@@ -41,6 +43,10 @@ Metrics/BlockLength:
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/MethodLength:
+  AllowedMethods:
+    - change
+    - down
+    - up
   Max: 20
 Metrics/ModuleLength:
   Exclude:


### PR DESCRIPTION
Migrations are a one time use and part of rails/gems DSL.

When merged, it could fails some builds with new `Lint/RedundantCopDisableDirective: Unnecessary disabling errors`, which will need to be adjusted.