### PR TITLE
Disable auto-correction for focused spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,8 @@ RSpec/ExpectInHook:
   Enabled: false
 RSpec/ExampleLength:
   Max: 25
+RSpec/Focus:
+  AutoCorrect: false
 RSpec/MultipleExpectations:
   Max: 10
 RSpec/MultipleMemoizedHelpers:


### PR DESCRIPTION
Running autocorrection on save, having the focus autocorrected means that it is always removed. However, we still want to be able to focus specs locally.

See this issue: https://github.com/Shopify/ruby-lsp/issues/596 and more specifically this comment: https://github.com/Shopify/ruby-lsp/issues/596#issuecomment-1488945827