### PR TITLE
Allow arrays, hashes and heredocs to be counted as one line

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,8 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - '**/*.rake'
     - 'Gemfile'
+Metrics/ClassLength:
+  CountAsOne: ["array", "hash", "heredoc"]
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/MethodLength:


### PR DESCRIPTION
See the reference [here](https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength). Array, hashes and heredoc do not meaningfully add to class complexity. Count them as one line.