### PR TITLE
Add new rubocop-factory_bot extension for Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require:
+  - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec


### PR DESCRIPTION
Adds [rubocop-factory_bot](https://github.com/rubocop/rubocop-factory_bot) extension to our global Rubocop config, as newly suggested by Rubocop :
```
The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-factory_bot

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```

Changes can be summarized as adding the gem to the Gemfile and adding a `require` in our global config, like so : https://github.com/hooktstudios/didacte/commit/06c2f6a95abdf45f66244325df1634060176f81a. These 2 requirements are on separate repositories (global config is done here, whereas Gemfile is updated in each repository), hence the several Pull Requests.

We will also need to add the gem in our repositories, so we will most likely have to merge the following Pull Requests first :
- [x] [PR for didacte (app)](https://github.com/hooktstudios/didacte/pull/6803)
- [x] [PR for didacte-site](https://github.com/hooktstudios/didacte-site/pull/1591)