### PR TITLE
DD-2209 Add `included` on BlockLength for ActiveSupport::Concern

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,7 @@ Metrics/BlockLength:
     - configure
     - draw
     - guard
+    - included
     - safety_assured
     - setup
     - up_only


### PR DESCRIPTION
Regarding this feedback https://github.com/hooktstudios/didacte/pull/8334/files#r1509468921

`included` is used for [ActiveSupport concern](https://api.rubyonrails.org/v7.1.3.2/classes/ActiveSupport/Concern.html) to define multiples methods, so it should not count as a single block of code