### PR TITLE
DD-2958 Add rubocop-rspec_rails require to config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 AllCops:
   # Let Rubocop determine Rails and Ruby version


### PR DESCRIPTION
>[!warning]
> Do not merge this PR before https://github.com/hooktstudios/didacte/pull/9101 is merged

Add new rubocop require config to global configuration file. The rspec_rails has been extracted to its own gem, so we need to require it manually once `rubocop-rspec` is updated to version 3.

