### PR TITLE
Use plugins syntax instead of require

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails


### PR DESCRIPTION
The syntax for adding plugins to rubocop has changed and is now creating warnings. This fixes the warning by using the [new recommended syntax](https://docs.rubocop.org/rubocop/plugin_migration_guide.html#for-plugin-users).