### PR TITLE
Revert "Use plugins syntax instead of require"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-plugins:
+require:
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails


### PR DESCRIPTION
Reverts hooktstudios/rubocop-hookt#16

We'll need to update rubocop(s) before using the new syntax, my bad 