### PR TITLE
Revert "Revert "Use plugins syntax instead of require""

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails


### PR DESCRIPTION
Now that https://github.com/hooktstudios/didacte/pull/10653 has been merged, it should be safe to merge this one.